### PR TITLE
Implements notification aknowledgment

### DIFF
--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/NotificationController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/NotificationController.kt
@@ -2,6 +2,7 @@ package com.ifpe.edu.br.airpowerserver.controller
 
 
 import com.ifpe.edu.br.airpowerserver.config.DownstreamServiceException
+import com.ifpe.edu.br.airpowerserver.dto.Id
 import com.ifpe.edu.br.airpowerserver.dto.error.ErrorCode
 import com.ifpe.edu.br.airpowerserver.dto.notification.AirPowerNotificationItem
 import com.ifpe.edu.br.airpowerserver.repository.airpower.AirPowerUserRepository
@@ -9,9 +10,8 @@ import com.ifpe.edu.br.airpowerserver.service.NotificationService
 import com.ifpe.edu.br.airpowerserver.service.ThingsBoardUserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import java.util.*
 
 @RestController
 @RequestMapping("/api/v1/notifications")
@@ -35,6 +35,30 @@ class NotificationController(
             val thingsBoardUserFromApi = thingsBoardService.getCurrentUser(storedAirPowerUser.id!!)
             val notifications = notificationService.getNotificationsForUser(thingsBoardUserFromApi.id.id)
             ResponseEntity.ok(notifications)
+        }
+    }
+
+    @PostMapping("/read")
+    fun refresh(
+        @RequestBody id: Id
+    ): ResponseEntity<Boolean> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val username = authentication?.name
+        return if (username == null) {
+            throw DownstreamServiceException(
+                ErrorCode.INVALID_REFRESH_TOKEN,
+                "user could not be found"
+            )
+        } else {
+            val storedAirPowerUser = airPowerUserRepository.findByEmail(username)
+            val thingsBoardUserFromApi = thingsBoardService.getCurrentUser(storedAirPowerUser.id!!)
+            val result = notificationService.markAsRead(
+                Id(
+                    id = id.id,
+                    entityType = ""
+                ), thingsBoardUserFromApi
+            )
+            ResponseEntity.ok(result)
         }
     }
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/NotificationController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/NotificationController.kt
@@ -46,7 +46,7 @@ class NotificationController(
         val username = authentication?.name
         return if (username == null) {
             throw DownstreamServiceException(
-                ErrorCode.INVALID_REFRESH_TOKEN,
+ErrorCode.INVALID_AIRPOWER_TOKEN,
                 "user could not be found"
             )
         } else {

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/NotificationService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/NotificationService.kt
@@ -79,7 +79,7 @@ class NotificationService(
         thingsBoardUserFromApi: ThingsBoardUser
     ): Boolean {
         logger.info("markAsRead: id: $notificationId user: $thingsBoardUserFromApi")
-        val url = "$thingsBoardApiUrl/api/notification/${notificationId.id}/read\n"
+val url = "$thingsBoardApiUrl/api/notification/${notificationId.id}/read"
         val requestEntity = HttpEntity<String>(tbServiceUtil.getAuthHeaders(thingsBoardUserFromApi.id.id))
         try {
             val response =

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/NotificationService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/NotificationService.kt
@@ -1,5 +1,7 @@
 package com.ifpe.edu.br.airpowerserver.service
 
+import com.ifpe.edu.br.airpowerserver.dto.Id
+import com.ifpe.edu.br.airpowerserver.dto.ThingsBoardUser
 import com.ifpe.edu.br.airpowerserver.dto.notification.AirPowerNotificationItem
 import com.ifpe.edu.br.airpowerserver.dto.notification.ThingsBoardNotification
 import com.ifpe.edu.br.airpowerserver.dto.notification.ThingsBoardNotificationResponse
@@ -7,6 +9,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
@@ -69,5 +72,22 @@ class NotificationService(
             dashboardId = tbNotification.info.dashboardId,
             status = tbNotification.status
         )
+    }
+
+    fun markAsRead(
+        notificationId: Id,
+        thingsBoardUserFromApi: ThingsBoardUser
+    ): Boolean {
+        logger.info("markAsRead: id: $notificationId user: $thingsBoardUserFromApi")
+        val url = "$thingsBoardApiUrl/api/notification/${notificationId.id}/read\n"
+        val requestEntity = HttpEntity<String>(tbServiceUtil.getAuthHeaders(thingsBoardUserFromApi.id.id))
+        try {
+            val response =
+                restTemplate.exchange(url, HttpMethod.PUT, requestEntity, Any::class.java)
+            return response.statusCode == HttpStatus.OK
+        } catch (e: HttpClientErrorException) {
+            logger.error("Error markAsRead:$e")
+            return false
+        }
     }
 }


### PR DESCRIPTION
Highlights
New API Endpoint for Acknowledgment: A new POST endpoint, /api/v1/notifications/read, has been added to the NotificationController. This endpoint allows clients to send a notification ID to mark it as read.
Notification Service Integration: The NotificationService now includes a markAsRead function. This function is responsible for making the necessary API calls to the external ThingsBoard system to update the status of a specified notification to 'read'.