### PR TITLE
39 criar logica para recuperar devices de um determinado dashboard

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:${jjwtVersion}")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:${jjwtVersion}")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
-    runtimeOnly("org.postgresql:postgresql")
+    implementation("org.postgresql:postgresql")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
@@ -1,0 +1,37 @@
+package com.ifpe.edu.br.airpowerserver.controller
+
+import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardInfo
+import com.ifpe.edu.br.airpowerserver.service.ThingsBoardDashboardService
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/user/{userId}/dashboards")
+class DashboardController(
+    private val dashboardService: ThingsBoardDashboardService
+) {
+    private val logger = LoggerFactory.getLogger(DashboardController::class.java)
+
+    @GetMapping
+    fun getDashboardsForUser(@PathVariable userId: String): ResponseEntity<List<DashboardInfo>> {
+        logger.info("Request received for dashboards of user: {}", userId)
+        val dashboards = dashboardService.getDashboardsForUser(UUID.fromString(userId))
+        return ResponseEntity.ok(dashboards)
+    }
+
+    @GetMapping("/{dashboardId}/device-ids")
+    fun getDeviceIdsFromDashboard(
+        @PathVariable userId: String,
+        @PathVariable dashboardId: String
+    ): ResponseEntity<List<String>> {
+        logger.info("Request received for device IDs from dashboard {} for user: {}", dashboardId, userId)
+        val deviceIds = dashboardService.getDeviceIdsFromDashboard(UUID.fromString(userId), dashboardId)
+        logger.info("deviceIds: {}", deviceIds)
+        return ResponseEntity.ok(deviceIds)
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
@@ -11,13 +11,13 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/v1/user/{userId}/dashboards")
+@RequestMapping("/api/v1/dashboards/")
 class DashboardController(
     private val dashboardService: ThingsBoardDashboardService
 ) {
     private val logger = LoggerFactory.getLogger(DashboardController::class.java)
 
-    @GetMapping
+    @GetMapping("{userId}/dashboards")
     fun getDashboardsForUser(@PathVariable userId: String): ResponseEntity<List<DashboardInfo>> {
         logger.info("Request received for dashboards of user: {}", userId)
         val dashboards = dashboardService.getDashboardsForUser(UUID.fromString(userId))
@@ -26,11 +26,10 @@ class DashboardController(
 
     @GetMapping("/{dashboardId}/device-ids")
     fun getDeviceIdsFromDashboard(
-        @PathVariable userId: String,
         @PathVariable dashboardId: String
     ): ResponseEntity<List<String>> {
-        logger.info("Request received for device IDs from dashboard {} for user: {}", dashboardId, userId)
-        val idObjects = dashboardService.getDeviceIdsFromDashboard(UUID.fromString(userId), dashboardId)
+        logger.info("Request received for device IDs from dashboard {}", dashboardId)
+        val idObjects = dashboardService.getDeviceIdsFromDashboard(dashboardId)
         val uuidStrings = idObjects.map { it.id.toString() }
         return ResponseEntity.ok(uuidStrings)
     }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
@@ -30,12 +30,8 @@ class DashboardController(
         @PathVariable dashboardId: String
     ): ResponseEntity<List<String>> {
         logger.info("Request received for device IDs from dashboard {} for user: {}", dashboardId, userId)
-        val deviceIds = dashboardService.getDeviceIdsFromDashboard(UUID.fromString(userId), dashboardId)
-        logger.info("deviceIds: {}", deviceIds)
-        val devicesStrings = emptyList<String>()
-        for (deviceId in deviceIds) {
-            devicesStrings.plus(deviceId.id.toString())
-        }
-        return ResponseEntity.ok(devicesStrings)
+        val idObjects = dashboardService.getDeviceIdsFromDashboard(UUID.fromString(userId), dashboardId)
+        val uuidStrings = idObjects.map { it.id.toString() }
+        return ResponseEntity.ok(uuidStrings)
     }
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
@@ -8,8 +8,16 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import java.util.*
 
+/**
+ * Controller responsible for handling requests related to dashboards.
+ *
+ * This controller provides endpoints for retrieving dashboard information and
+ * associated device IDs.
+ *
+ * @property dashboardService The service responsible for dashboard-related business logic.
+ */
 @RestController
 @RequestMapping("/api/v1/dashboards/")
 class DashboardController(
@@ -17,6 +25,12 @@ class DashboardController(
 ) {
     private val logger = LoggerFactory.getLogger(DashboardController::class.java)
 
+    /**
+     * Retrieves all dashboards associated with a specific user.
+     *
+     * @param userId The UUID String of the user.
+     * @return A [ResponseEntity] containing a list of [DashboardInfo] objects.
+     */
     @GetMapping("{userId}/dashboards")
     fun getDashboardsForUser(@PathVariable userId: String): ResponseEntity<List<DashboardInfo>> {
         logger.info("Request received for dashboards of user: {}", userId)
@@ -24,7 +38,13 @@ class DashboardController(
         return ResponseEntity.ok(dashboards)
     }
 
-    @GetMapping("/{dashboardId}/device-ids")
+    /**
+     * Retrieves all device IDs associated with a specific dashboard.
+     *
+     * @param dashboardId The UUID String of the dashboard.
+     * @return A [ResponseEntity] containing a list of device ID strings.
+     */
+    @GetMapping("{dashboardId}/device-ids")
     fun getDeviceIdsFromDashboard(
         @PathVariable dashboardId: String
     ): ResponseEntity<List<String>> {

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/DashboardController.kt
@@ -32,6 +32,10 @@ class DashboardController(
         logger.info("Request received for device IDs from dashboard {} for user: {}", dashboardId, userId)
         val deviceIds = dashboardService.getDeviceIdsFromDashboard(UUID.fromString(userId), dashboardId)
         logger.info("deviceIds: {}", deviceIds)
-        return ResponseEntity.ok(deviceIds)
+        val devicesStrings = emptyList<String>()
+        for (deviceId in deviceIds) {
+            devicesStrings.plus(deviceId.id.toString())
+        }
+        return ResponseEntity.ok(devicesStrings)
     }
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/ThingsBoardDataResponse.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/ThingsBoardDataResponse.kt
@@ -1,0 +1,10 @@
+package com.ifpe.edu.br.airpowerserver.dto
+
+data class ThingsBoardDataResponse<T>(
+    val data: List<T>
+)
+{
+    override fun toString(): String {
+        return "ThingsBoardDataResponse(data=$data)"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/AliasFilter.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/AliasFilter.kt
@@ -1,7 +1,11 @@
 package com.ifpe.edu.br.airpowerserver.dto.dashboards
 
 data class AliasFilter(
-    val type: String?, // Ex: "singleEntity", "entityList", etc.
-    val singleEntity: SingleEntity?, // Usado quando é um dispositivo fixo
-    val entityList: List<String>? // Usado raramente para listas fixas
+    val type: String?, // "relationsQuery", "entityList", etc.
+    val resolveMultiple: Boolean? = false,
+    val entityList: List<String>?, // Para listas manuais pequenas
+    // Novos campos para suportar a Query de Relação:
+    val rootEntity: SingleEntity?,
+    val direction: String?, // "FROM" ou "TO"
+    val relationType: String? // ex: "Contains"
 )

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/AliasFilter.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/AliasFilter.kt
@@ -1,0 +1,7 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class AliasFilter(
+    val type: String?, // Ex: "singleEntity", "entityList", etc.
+    val singleEntity: SingleEntity?, // Usado quando é um dispositivo fixo
+    val entityList: List<String>? // Usado raramente para listas fixas
+)

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardConfig.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardConfig.kt
@@ -1,0 +1,10 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class DashboardConfig(
+    val configuration: DashboardConfiguration
+)
+{
+    override fun toString(): String {
+        return "DashboardConfig(configuration=$configuration)"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardConfiguration.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardConfiguration.kt
@@ -1,10 +1,6 @@
 package com.ifpe.edu.br.airpowerserver.dto.dashboards
 
 data class DashboardConfiguration(
-    val widgets: Map<String, Widget>
+    val widgets: Map<String, Widget>?, // Pode ser nulo
+    val entityAliases: Map<String, EntityAlias>? // ADICIONADO: Onde os IDs realmente vivem
 )
-{
-    override fun toString(): String {
-        return "DashboardConfiguration(widgets=$widgets)"
-    }
-}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardConfiguration.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardConfiguration.kt
@@ -1,0 +1,10 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class DashboardConfiguration(
+    val widgets: Map<String, Widget>
+)
+{
+    override fun toString(): String {
+        return "DashboardConfiguration(widgets=$widgets)"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardInfo.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardInfo.kt
@@ -5,10 +5,11 @@ import com.ifpe.edu.br.airpowerserver.dto.Id
 data class DashboardInfo(
     val id: Id,
     val name: String,
-    val title: String
+    val title: String,
+    var devicesIds: List<String> = emptyList()
 )
 {
     override fun toString(): String {
-        return "DashboardInfo(id=$id, name='$name', title='$title')"
+        return "DashboardInfo(id=$id, name='$name', title='$title', devicesIds=$devicesIds)"
     }
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardInfo.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/DashboardInfo.kt
@@ -1,0 +1,14 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+import com.ifpe.edu.br.airpowerserver.dto.Id
+
+data class DashboardInfo(
+    val id: Id,
+    val name: String,
+    val title: String
+)
+{
+    override fun toString(): String {
+        return "DashboardInfo(id=$id, name='$name', title='$title')"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/Datasource.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/Datasource.kt
@@ -1,0 +1,13 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+import com.ifpe.edu.br.airpowerserver.dto.Id
+
+data class Datasource(
+    val entityId: Id?,
+    val deviceId: Id?
+)
+{
+    override fun toString(): String {
+        return "Datasource(entityId=$entityId, deviceId=$deviceId)"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/EntityAlias.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/EntityAlias.kt
@@ -1,0 +1,7 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class EntityAlias(
+    val id: String,
+    val alias: String,
+    val filter: AliasFilter?
+)

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/SingleEntity.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/SingleEntity.kt
@@ -1,0 +1,6 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class SingleEntity(
+    val entityType: String,
+    val id: String
+)

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/Widget.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/Widget.kt
@@ -1,0 +1,10 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class Widget(
+    val config: WidgetConfig
+)
+{
+    override fun toString(): String {
+        return "Widget(config=$config)"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/WidgetConfig.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/dto/dashboards/WidgetConfig.kt
@@ -1,0 +1,10 @@
+package com.ifpe.edu.br.airpowerserver.dto.dashboards
+
+data class WidgetConfig(
+    val datasources: List<Datasource>
+)
+{
+    override fun toString(): String {
+        return "WidgetConfig(datasources=$datasources)"
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardAlarmService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardAlarmService.kt
@@ -21,9 +21,9 @@ class ThingsBoardAlarmService(
 
     private val logger = LoggerFactory.getLogger(ThingsBoardAlarmService::class.java)
 
-    fun getAllAlarmInfoForUserId(userId: UUID): List<APAlarmInfo>{
+    fun getAllAlarmInfoForUserId(userId: UUID): List<APAlarmInfo> {
         try {
-            val url = "$thingsBoardApiUrl/api/alarms${getAlarmQuery(userId)}"
+            val url = "$thingsBoardApiUrl/api/alarms${getAlarmQuery(userId = userId, status = "ACTIVE_UNACK")}"
             logger.debug("Requesting alarms from URL: $url")
             val requestEntity = HttpEntity<String>(tbServiceUtil.getAuthHeaders(userId))
             val response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, TBAlarmResponse::class.java)
@@ -55,6 +55,7 @@ class ThingsBoardAlarmService(
     ): String {
         val queryParams = mutableListOf<String>()
 
+        userId.let { queryParams.add("userId=$it") }
         searchStatus?.let { queryParams.add("searchStatus=$it") }
         status?.let { queryParams.add("status=$it") }
         assigneeId?.let { queryParams.add("assigneeId=$it") }
@@ -70,5 +71,32 @@ class ThingsBoardAlarmService(
         queryParams.add("pageSize=$pageSize")
 
         return if (queryParams.isNotEmpty()) "?" + queryParams.joinToString("&") else ""
+    }
+
+    /**
+     * Retrieves alarms that are not acknowledged.
+     *
+     * This function filters alarms on the server-side by their 'acknowledged' status.
+     * It returns alarms where 'acknowledged' is false, regardless of their 'cleared' status.
+     *
+     * @param userId The UUID of the user.
+     * @return A list of [APAlarmInfo] for unacknowledged alarms.
+     */
+    fun getUnacknowledgedAlarms(userId: UUID): List<APAlarmInfo> {
+        try {
+            val url = "$thingsBoardApiUrl/api/alarms${getAlarmQuery(userId, searchStatus = "UNACK")}"
+            logger.debug("Requesting unacknowledged alarms from URL: $url")
+            val requestEntity = HttpEntity<String>(tbServiceUtil.getAuthHeaders(userId))
+            val response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, TBAlarmResponse::class.java)
+            return if (response.statusCode.is2xxSuccessful && response.body != null) {
+                response.body!!.toAirPowerAlarmInfo()
+            } else {
+                logger.error("Failed to fetch unacknowledged alarms. Status: {}", response.statusCode)
+                throw IllegalStateException("Failed to fetch unacknowledged alarms from ThingsBoard: ${response.statusCode}")
+            }
+        } catch (e: Exception) {
+            logger.error("Exception when calling ThingsBoard API to fetch unacknowledged alarms", e)
+            throw IllegalStateException("Failed to communicate with ThingsBoard service: ${e.message}")
+        }
     }
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
@@ -1,0 +1,79 @@
+package com.ifpe.edu.br.airpowerserver.service
+
+import com.ifpe.edu.br.airpowerserver.dto.ThingsBoardDataResponse
+import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardConfig
+import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardInfo
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestTemplate
+import java.util.UUID
+
+@Service
+class ThingsBoardDashboardService(
+    private val restTemplate: RestTemplate,
+    private val thingsBoardServiceUtil: ThingsBoardServiceUtil,
+    @Value("\${thingsboard.api.url}") private val thingsBoardApiUrl: String
+){
+    private val logger = LoggerFactory.getLogger(ThingsBoardDashboardService::class.java)
+
+    /**
+     * Fetches all dashboards available for the tenant associated with the given user.
+     */
+    fun getDashboardsForUser(userId: UUID): List<DashboardInfo> {
+        val url = "$thingsBoardApiUrl/api/tenant/dashboards?page=0&pageSize=1000"
+        logger.debug("Requesting dashboards for user {} from URL: {}", userId, url)
+        val requestEntity = HttpEntity<String>(thingsBoardServiceUtil.getAuthHeaders(userId))
+
+        try {
+            val responseType = object : ParameterizedTypeReference<ThingsBoardDataResponse<DashboardInfo>>() {}
+            val response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, responseType)
+
+            return response.body?.data ?: emptyList()
+        } catch (e: HttpClientErrorException) {
+            logger.error("Error fetching dashboards for user {}: {} - {}", userId, e.statusCode, e.responseBodyAsString)
+            throw IllegalStateException("Failed to fetch dashboards from ThingsBoard: ${e.statusCode}")
+        } catch (e: Exception) {
+            logger.error("An unexpected error occurred while fetching dashboards for user {}: {}", userId, e.message)
+            throw e
+        }
+    }
+
+    /**
+     * Fetches the unique device IDs from all widgets within a specific dashboard.
+     */
+    fun getDeviceIdsFromDashboard(userId: UUID, dashboardId: String): List<String> {
+        val url = "$thingsBoardApiUrl/api/dashboard/$dashboardId"
+        logger.debug("Requesting dashboard details for user {} from URL: {}", userId, url)
+        val requestEntity = HttpEntity<String>(thingsBoardServiceUtil.getAuthHeaders(userId))
+
+        try {
+            val response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, DashboardConfig::class.java)
+            val dashboardConfig = response.body ?: return emptyList()
+
+            val deviceIds = mutableSetOf<String>()
+
+            dashboardConfig.configuration.widgets.values.forEach { widget ->
+                widget.config.datasources.forEach { datasource ->
+                    // Add entityId or the legacy deviceId, preferring entityId
+                    val id = datasource.entityId ?: datasource.deviceId
+                    if (id != null) {
+                        deviceIds.add(id.toString())
+                    }
+                }
+            }
+            return deviceIds.toList()
+
+        } catch (e: HttpClientErrorException) {
+            logger.error("Error fetching dashboard details for id {}: {} - {}", dashboardId, e.statusCode, e.responseBodyAsString)
+            throw IllegalStateException("Failed to fetch dashboard details from ThingsBoard: ${e.statusCode}")
+        } catch (e: Exception) {
+            logger.error("An unexpected error occurred while fetching dashboard details for id {}: {}", dashboardId, e.message)
+            throw e
+        }
+    }
+}

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
@@ -1,79 +1,105 @@
 package com.ifpe.edu.br.airpowerserver.service
 
-import com.ifpe.edu.br.airpowerserver.dto.ThingsBoardDataResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ifpe.edu.br.airpowerserver.dto.Id
 import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardConfig
 import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardInfo
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.core.ParameterizedTypeReference
-import org.springframework.http.HttpEntity
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpMethod
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
-import org.springframework.web.client.HttpClientErrorException
-import org.springframework.web.client.RestTemplate
-import java.util.UUID
+import java.sql.ResultSet
+import java.util.*
 
 @Service
 class ThingsBoardDashboardService(
-    private val restTemplate: RestTemplate,
-    private val thingsBoardServiceUtil: ThingsBoardServiceUtil,
-    @Value("\${thingsboard.api.url}") private val thingsBoardApiUrl: String
-){
+    private val namedJdbcTemplate: NamedParameterJdbcTemplate,
+    private val objectMapper: ObjectMapper
+) {
     private val logger = LoggerFactory.getLogger(ThingsBoardDashboardService::class.java)
 
-    /**
-     * Fetches all dashboards available for the tenant associated with the given user.
-     */
+    // CORREÇÃO: Usamos 'title' para preencher tanto o title quanto o name,
+    // pois a coluna 'name' não existe no banco.
+    private val dashboardInfoRowMapper = RowMapper<DashboardInfo> { rs: ResultSet, _: Int ->
+        val title = rs.getString("title")
+        DashboardInfo(
+            id = Id(
+                entityType = "DASHBOARD",
+                id = UUID.fromString(rs.getString("id"))
+            ),
+            name = title,
+            title = title
+        )
+    }
+
     fun getDashboardsForUser(userId: UUID): List<DashboardInfo> {
-        val url = "$thingsBoardApiUrl/api/tenant/dashboards?page=0&pageSize=1000"
-        logger.debug("Requesting dashboards for user {} from URL: {}", userId, url)
-        val requestEntity = HttpEntity<String>(thingsBoardServiceUtil.getAuthHeaders(userId))
+        // CORREÇÃO: Removida a coluna d.name do SELECT.
+        // Adicionado CAST(u.id AS uuid) ou ::uuid para garantir compatibilidade de tipos no Postgres.
+        // Nota: A lógica de JOIN assume que a relação está populada na tabela 'relation'.
+        // Se esta query não retornar nada, podemos tentar usar a coluna 'assigned_customers'.
+        val sql = """
+            SELECT d.id, d.title
+            FROM dashboard d
+            JOIN relation r ON d.id = r.to_id
+            JOIN tb_user u ON r.from_id = u.customer_id
+            WHERE u.id = :userId
+              AND r.relation_type_group = 'DASHBOARD'
+              AND r.from_type = 'CUSTOMER'
+              AND r.to_type = 'DASHBOARD'
+        """.trimIndent()
 
-        try {
-            val responseType = object : ParameterizedTypeReference<ThingsBoardDataResponse<DashboardInfo>>() {}
-            val response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, responseType)
+        val params = MapSqlParameterSource().addValue("userId", userId)
+        logger.debug("Buscando dashboards no DB para o usuário: {}", userId)
 
-            return response.body?.data ?: emptyList()
-        } catch (e: HttpClientErrorException) {
-            logger.error("Error fetching dashboards for user {}: {} - {}", userId, e.statusCode, e.responseBodyAsString)
-            throw IllegalStateException("Failed to fetch dashboards from ThingsBoard: ${e.statusCode}")
+        return try {
+            namedJdbcTemplate.query(sql, params, dashboardInfoRowMapper)
         } catch (e: Exception) {
-            logger.error("An unexpected error occurred while fetching dashboards for user {}: {}", userId, e.message)
-            throw e
+            logger.error("Erro ao buscar dashboards diretamente do DB para o usuário {}: {}", userId, e.message)
+            // É boa prática relançar ou tratar de forma que o controller saiba que falhou,
+            // mas retornar lista vazia é seguro para evitar crash.
+            emptyList()
         }
     }
 
     /**
-     * Fetches the unique device IDs from all widgets within a specific dashboard.
+     * Busca os IDs de dispositivos únicos de um dashboard específico, lendo a configuração JSON
+     * diretamente do banco de dados.
      */
-    fun getDeviceIdsFromDashboard(userId: UUID, dashboardId: String): List<String> {
-        val url = "$thingsBoardApiUrl/api/dashboard/$dashboardId"
-        logger.debug("Requesting dashboard details for user {} from URL: {}", userId, url)
-        val requestEntity = HttpEntity<String>(thingsBoardServiceUtil.getAuthHeaders(userId))
+    fun getDeviceIdsFromDashboard(userId: UUID, dashboardId: String): List<Id> {
+        // O userId é usado para contexto de autorização (implícito), mas a query só precisa do dashboardId
+        val sql = "SELECT configuration::text FROM dashboard WHERE id = :dashboardId"
+        val params = MapSqlParameterSource().addValue("dashboardId", UUID.fromString(dashboardId))
+        logger.debug("Buscando configuração do dashboard {} para o usuário {}", dashboardId, userId)
 
         try {
-            val response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, DashboardConfig::class.java)
-            val dashboardConfig = response.body ?: return emptyList()
+            // 1. Buscar o JSON de configuração como uma String
+            val configJson = namedJdbcTemplate.queryForObject(sql, params, String::class.java)
+                ?: throw EmptyResultDataAccessException("Configuração do dashboard não encontrada", 1)
 
-            val deviceIds = mutableSetOf<String>()
+            // 2. Parsear o JSON usando ObjectMapper e os DTOs que já criamos
+            val dashboardConfig = objectMapper.readValue<DashboardConfig>(configJson)
+            val deviceIds = mutableSetOf<Id>()
 
+            // 3. Extrair os IDs (lógica idêntica à anterior)
             dashboardConfig.configuration.widgets.values.forEach { widget ->
                 widget.config.datasources.forEach { datasource ->
-                    // Add entityId or the legacy deviceId, preferring entityId
                     val id = datasource.entityId ?: datasource.deviceId
                     if (id != null) {
-                        deviceIds.add(id.toString())
+                        deviceIds.add(id)
                     }
                 }
             }
             return deviceIds.toList()
 
-        } catch (e: HttpClientErrorException) {
-            logger.error("Error fetching dashboard details for id {}: {} - {}", dashboardId, e.statusCode, e.responseBodyAsString)
-            throw IllegalStateException("Failed to fetch dashboard details from ThingsBoard: ${e.statusCode}")
+        } catch (e: EmptyResultDataAccessException) {
+            logger.warn("Nenhum dashboard encontrado no DB com o ID: {} para usuário {}", dashboardId, userId)
+            return emptyList()
         } catch (e: Exception) {
-            logger.error("An unexpected error occurred while fetching dashboard details for id {}: {}", dashboardId, e.message)
-            throw e
+            logger.error("Falha ao parsear a configuração do dashboard {} (do DB): {}", dashboardId, e.message)
+            return emptyList()
         }
     }
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
@@ -62,48 +62,101 @@ class ThingsBoardDashboardService(
     /**
      * Busca os IDs de dispositivos únicos de um dashboard específico.
      */
-    fun getDeviceIdsFromDashboard(userId: UUID, dashboardId: String): List<Id> {
-        val sql = "SELECT configuration::text FROM dashboard WHERE id = :dashboardId"
+    fun getDeviceIdsFromDashboard(customerId: UUID, dashboardId: String): List<Id> {
+        val sqlConfig = "SELECT configuration::text FROM dashboard WHERE id = :dashboardId"
         val params = MapSqlParameterSource().addValue("dashboardId", UUID.fromString(dashboardId))
-        logger.debug("Buscando configuração do dashboard {} para o usuário {}", dashboardId, userId)
 
         try {
-            val configJson = namedJdbcTemplate.queryForObject(sql, params, String::class.java)
-                ?: throw EmptyResultDataAccessException("Configuração do dashboard não encontrada", 1)
-            val dashboardConfiguration = objectMapper.readValue<DashboardConfiguration>(configJson)
-            val deviceIds = mutableSetOf<Id>()
-            dashboardConfiguration.entityAliases?.values?.forEach { alias ->
-                if (alias.filter?.type == "singleEntity" &&
-                    alias.filter.singleEntity?.entityType == "DEVICE") {
+            val configJson = namedJdbcTemplate.queryForObject(sqlConfig, params, String::class.java)
+                ?: throw EmptyResultDataAccessException(1)
 
-                    try {
-                        val uuid = UUID.fromString(alias.filter.singleEntity.id)
-                        deviceIds.add(Id(entityType = "DEVICE", id = uuid))
-                    } catch (e: Exception) {
-                        logger.warn("UUID inválido no Alias: {}", alias.filter.singleEntity.id)
-                    }
-                }
-            }
-            dashboardConfiguration.widgets?.values?.forEach { widget ->
-                widget.config.datasources.forEach { datasource ->
-                    val idString = datasource.entityId ?: datasource.deviceId
-                    if (idString != null) {
-                        try {
-                            deviceIds.add(Id(entityType = "DEVICE", id = UUID.fromString(idString.id.toString())))
-                        } catch (e: Exception) {
-                            logger.warn("UUID inválido encontrado no widget do dashboard {}: {}", dashboardId, idString)
+            val dashboardConfig = objectMapper.readValue<DashboardConfiguration>(configJson)
+            val deviceIds = mutableSetOf<Id>()
+
+            dashboardConfig.entityAliases?.values?.forEach { alias ->
+                val filter = alias.filter ?: return@forEach
+
+                when (filter.type) {
+                    // ---------------------------------------------------------
+                    // OPÇÃO 1: Lista Manual (Entity List)
+                    // Útil para grupos pequenos e fixos (ex: A e B)
+                    // Configurado na GUI como Filter Type: "Entity List"
+                    // ---------------------------------------------------------
+                    "entityList" -> {
+                        filter.entityList?.forEach { idStr ->
+                            try {
+                                deviceIds.add(Id(entityType = "DEVICE", id = UUID.fromString(idStr)))
+                            } catch (e: Exception) { logger.warn("UUID inválido na lista: $idStr") }
                         }
                     }
+
+                    // ---------------------------------------------------------
+                    // OPÇÃO 2: Relations Query (A solução robusta)
+                    // Busca devices conectados a um Asset específico.
+                    // ---------------------------------------------------------
+                    "relationsQuery" -> {
+                        val rootId = filter.rootEntity?.id
+                        val direction = filter.direction // FROM ou TO
+                        // Se o usuário não definir relationType na GUI, o TB às vezes omite ou usa "Contains"
+                        val relationType = filter.relationType
+
+                        if (rootId != null && direction != null) {
+                            // Busca dinâmica na tabela de relações
+                            val relations = findRelatedDevices(
+                                UUID.fromString(rootId),
+                                direction,
+                                relationType
+                            )
+                            deviceIds.addAll(relations)
+                        }
+                    }
+
+                    // ... outros casos (singleEntity, etc) ...
                 }
             }
-            logger.info("Encontrados {} dispositivos no dashboard {}", deviceIds.size, dashboardId)
+
             return deviceIds.toList()
-        } catch (e: EmptyResultDataAccessException) {
-            logger.warn("Nenhum dashboard encontrado no DB com o ID: {} para usuário {}", dashboardId, userId)
-            return emptyList()
+
         } catch (e: Exception) {
-            logger.error("Falha ao parsear a configuração do dashboard {} (do DB): {}", dashboardId, e.message)
+            logger.error("Erro ao resolver dashboard {}: {}", dashboardId, e.message)
             return emptyList()
         }
     }
+
+    /**
+     * Busca na tabela 'relation' do ThingsBoard.
+     * Estrutura da tabela: from_id, from_type, to_id, to_type, relation_type_group, relation_type
+     */
+    private fun findRelatedDevices(rootEntityId: UUID, direction: String, relationType: String?): List<Id> {
+        // Se direction é FROM, o Asset é o 'from_id' e buscamos os 'to_id' (os devices)
+        // Se direction é TO, o Asset é o 'to_id' (menos comum para agrupamento)
+
+        val isFrom = direction.equals("FROM", ignoreCase = true)
+
+        val selectColumn = if (isFrom) "to_id" else "from_id"
+        val whereColumn = if (isFrom) "from_id" else "to_id"
+        // Garantimos que só retornamos dispositivos
+        val targetTypeColumn = if (isFrom) "to_type" else "from_type"
+
+        var sql = """
+            SELECT $selectColumn as device_id 
+            FROM relation 
+            WHERE $whereColumn = :rootId 
+              AND $targetTypeColumn = 'DEVICE'
+              AND relation_type_group = 'COMMON'
+        """
+
+        val params = MapSqlParameterSource().addValue("rootId", rootEntityId)
+
+        // Adiciona filtro por tipo de relação se especificado (ex: 'Contains')
+        if (!relationType.isNullOrBlank()) {
+            sql += " AND relation_type = :relType"
+            params.addValue("relType", relationType)
+        }
+
+        return namedJdbcTemplate.query(sql, params) { rs, _ ->
+            Id(entityType = "DEVICE", id = UUID.fromString(rs.getString("device_id")))
+        }
+    }
+
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.ifpe.edu.br.airpowerserver.dto.Id
 import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardConfig
+import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardConfiguration
 import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardInfo
 import org.slf4j.LoggerFactory
 import org.springframework.dao.EmptyResultDataAccessException
@@ -21,8 +22,6 @@ class ThingsBoardDashboardService(
 ) {
     private val logger = LoggerFactory.getLogger(ThingsBoardDashboardService::class.java)
 
-    // CORREÇÃO: Usamos 'title' para preencher tanto o title quanto o name,
-    // pois a coluna 'name' não existe no banco.
     private val dashboardInfoRowMapper = RowMapper<DashboardInfo> { rs: ResultSet, _: Int ->
         val title = rs.getString("title")
         DashboardInfo(
@@ -36,10 +35,8 @@ class ThingsBoardDashboardService(
     }
 
     fun getDashboardsForUser(userId: UUID): List<DashboardInfo> {
-        // CORREÇÃO: Removida a coluna d.name do SELECT.
-        // Adicionado CAST(u.id AS uuid) ou ::uuid para garantir compatibilidade de tipos no Postgres.
         // Nota: A lógica de JOIN assume que a relação está populada na tabela 'relation'.
-        // Se esta query não retornar nada, podemos tentar usar a coluna 'assigned_customers'.
+        // Se esta query não retornar nada, devemos usar a coluna 'assigned_customers'.
         val sql = """
             SELECT d.id, d.title
             FROM dashboard d
@@ -58,42 +55,49 @@ class ThingsBoardDashboardService(
             namedJdbcTemplate.query(sql, params, dashboardInfoRowMapper)
         } catch (e: Exception) {
             logger.error("Erro ao buscar dashboards diretamente do DB para o usuário {}: {}", userId, e.message)
-            // É boa prática relançar ou tratar de forma que o controller saiba que falhou,
-            // mas retornar lista vazia é seguro para evitar crash.
             emptyList()
         }
     }
 
     /**
-     * Busca os IDs de dispositivos únicos de um dashboard específico, lendo a configuração JSON
-     * diretamente do banco de dados.
+     * Busca os IDs de dispositivos únicos de um dashboard específico.
      */
     fun getDeviceIdsFromDashboard(userId: UUID, dashboardId: String): List<Id> {
-        // O userId é usado para contexto de autorização (implícito), mas a query só precisa do dashboardId
         val sql = "SELECT configuration::text FROM dashboard WHERE id = :dashboardId"
         val params = MapSqlParameterSource().addValue("dashboardId", UUID.fromString(dashboardId))
         logger.debug("Buscando configuração do dashboard {} para o usuário {}", dashboardId, userId)
 
         try {
-            // 1. Buscar o JSON de configuração como uma String
             val configJson = namedJdbcTemplate.queryForObject(sql, params, String::class.java)
                 ?: throw EmptyResultDataAccessException("Configuração do dashboard não encontrada", 1)
-
-            // 2. Parsear o JSON usando ObjectMapper e os DTOs que já criamos
-            val dashboardConfig = objectMapper.readValue<DashboardConfig>(configJson)
+            val dashboardConfiguration = objectMapper.readValue<DashboardConfiguration>(configJson)
             val deviceIds = mutableSetOf<Id>()
+            dashboardConfiguration.entityAliases?.values?.forEach { alias ->
+                if (alias.filter?.type == "singleEntity" &&
+                    alias.filter.singleEntity?.entityType == "DEVICE") {
 
-            // 3. Extrair os IDs (lógica idêntica à anterior)
-            dashboardConfig.configuration.widgets.values.forEach { widget ->
-                widget.config.datasources.forEach { datasource ->
-                    val id = datasource.entityId ?: datasource.deviceId
-                    if (id != null) {
-                        deviceIds.add(id)
+                    try {
+                        val uuid = UUID.fromString(alias.filter.singleEntity.id)
+                        deviceIds.add(Id(entityType = "DEVICE", id = uuid))
+                    } catch (e: Exception) {
+                        logger.warn("UUID inválido no Alias: {}", alias.filter.singleEntity.id)
                     }
                 }
             }
+            dashboardConfiguration.widgets?.values?.forEach { widget ->
+                widget.config.datasources.forEach { datasource ->
+                    val idString = datasource.entityId ?: datasource.deviceId
+                    if (idString != null) {
+                        try {
+                            deviceIds.add(Id(entityType = "DEVICE", id = UUID.fromString(idString.id.toString())))
+                        } catch (e: Exception) {
+                            logger.warn("UUID inválido encontrado no widget do dashboard {}: {}", dashboardId, idString)
+                        }
+                    }
+                }
+            }
+            logger.info("Encontrados {} dispositivos no dashboard {}", deviceIds.size, dashboardId)
             return deviceIds.toList()
-
         } catch (e: EmptyResultDataAccessException) {
             logger.warn("Nenhum dashboard encontrado no DB com o ID: {} para usuário {}", dashboardId, userId)
             return emptyList()

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
@@ -14,6 +14,15 @@ import org.springframework.stereotype.Service
 import java.sql.ResultSet
 import java.util.*
 
+/**
+ * Service class for handling business logic related to ThingsBoard dashboards.
+ *
+ * This service interacts directly with the ThingsBoard database to retrieve dashboard
+ * and device information, bypassing the ThingsBoard API for performance.
+ *
+ * @property namedJdbcTemplate The template for executing named parameter SQL queries.
+ * @property objectMapper The mapper for handling JSON serialization and deserialization.
+ */
 @Service
 class ThingsBoardDashboardService(
     private val namedJdbcTemplate: NamedParameterJdbcTemplate,
@@ -33,9 +42,17 @@ class ThingsBoardDashboardService(
         )
     }
 
+    /**
+     * Retrieves all dashboards assigned to a specific user.
+     *
+     * This method queries the database to find dashboards related to the user's customer entity
+     * and then populates each dashboard with its associated device IDs.
+     *
+     * @param userId The UUID of the user.
+     * @return A list of [DashboardInfo] objects, each containing details about a dashboard
+     *         and the IDs of devices associated with it. Returns an empty list if an error occurs.
+     */
     fun getDashboardsForUser(userId: UUID): List<DashboardInfo> {
-        // Nota: A lógica de JOIN assume que a relação está populada na tabela 'relation'.
-        // Se esta query não retornar nada, devemos usar a coluna 'assigned_customers'.
         val sql = """
             SELECT d.id, d.title
             FROM dashboard d
@@ -51,7 +68,12 @@ class ThingsBoardDashboardService(
         logger.debug("Buscando dashboards no DB para o usuário: {}", userId)
 
         return try {
-            namedJdbcTemplate.query(sql, params, dashboardInfoRowMapper)
+            val dashboards = namedJdbcTemplate.query(sql, params, dashboardInfoRowMapper)
+            dashboards.forEach { dashboard ->
+                dashboard.devicesIds = getDeviceIdsFromDashboard(dashboard.id.id.toString())
+                    .map { it.id.toString() }
+            }
+            dashboards
         } catch (e: Exception) {
             logger.error("Erro ao buscar dashboards diretamente do DB para o usuário {}: {}", userId, e.message)
             emptyList()
@@ -59,7 +81,14 @@ class ThingsBoardDashboardService(
     }
 
     /**
-     * Busca os IDs de dispositivos únicos de um dashboard específico.
+     * Extracts all unique device IDs from a specific dashboard's configuration.
+     *
+     * The method parses the dashboard's configuration JSON to find device aliases,
+     * which can be defined as a static list ('entityList') or a dynamic query ('relationsQuery').
+     *
+     * @param dashboardId The UUID of the dashboard as a String.
+     * @return A list of unique [Id] objects for the devices found in the dashboard.
+     *         Returns an empty list if the dashboard is not found or an error occurs.
      */
     fun getDeviceIdsFromDashboard(dashboardId: String): List<Id> {
         val sqlConfig = "SELECT configuration::text FROM dashboard WHERE id = :dashboardId"
@@ -76,8 +105,6 @@ class ThingsBoardDashboardService(
                 val filter = alias.filter ?: return@forEach
 
                 when (filter.type) {
-                    // OPÇÃO 1: Lista Manual (Entity List)
-                    // Configurado na GUI como Filter Type: "Entity List"
                     "entityList" -> {
                         filter.entityList?.forEach { idStr ->
                             try {
@@ -85,12 +112,9 @@ class ThingsBoardDashboardService(
                             } catch (e: Exception) { logger.warn("UUID inválido na lista: $idStr") }
                         }
                     }
-                    // OPÇÃO 2: Relations Query
-                    // Busca devices conectados a um Asset específico.
                     "relationsQuery" -> {
                         val rootId = filter.rootEntity?.id
-                        val direction = filter.direction // FROM ou TO
-                        // Se o usuário não definir relationType na GUI, o TB às vezes omite ou usa "Contains"
+                        val direction = filter.direction
                         val relationType = filter.relationType
                         if (rootId != null && direction != null) {
                             val relations = findRelatedDevices(
@@ -111,21 +135,25 @@ class ThingsBoardDashboardService(
     }
 
     /**
-     * Busca RECURSIVAMENTE na tabela 'relation' do ThingsBoard.
-     * Encontra todos os dispositivos descendentes, não importa a profundidade (Asset -> Asset -> Device).
+     * Recursively finds related devices in the ThingsBoard 'relation' table.
+     *
+     * This method performs a recursive SQL query to traverse the entity hierarchy
+     * (e.g., Asset -> Asset -> Device) and find all descendant devices.
+     *
+     * @param rootEntityId The starting UUID for the recursive search.
+     * @param direction The direction of the relationship ('FROM' or 'TO').
+     * @param relationType The specific type of relation to follow (e.g., 'Contains').
+     * @return A list of [Id] objects representing the found devices.
      */
     private fun findRelatedDevices(rootEntityId: UUID, direction: String, relationType: String?): List<Id> {
         val isFrom = direction.equals("FROM", ignoreCase = true)
 
-        // Se a direção é FROM (Root -> Filhos), a recursão segue from_id -> to_id.
         val parentColumn = if (isFrom) "from_id" else "to_id"
         val childColumn = if (isFrom) "to_id" else "from_id"
         val childTypeColumn = if (isFrom) "to_type" else "from_type"
 
-        // SQL Recursivo para PostgreSQL
         val sql = """
             WITH RECURSIVE entity_tree AS (
-                -- Caso Base: Encontra os filhos diretos da Entidade Raiz (ex: Campus -> Bloco A)
                 SELECT 
                     $childColumn as entity_id, 
                     $childTypeColumn as entity_type
@@ -136,7 +164,6 @@ class ThingsBoardDashboardService(
                 
                 UNION ALL
                 
-                -- Passo Recursivo: Encontra os filhos dos filhos (ex: Bloco A -> Device)
                 SELECT 
                     r.$childColumn, 
                     r.$childTypeColumn
@@ -145,7 +172,6 @@ class ThingsBoardDashboardService(
                 WHERE r.relation_type_group = 'COMMON'
                   ${if (!relationType.isNullOrBlank()) "AND r.relation_type = :relType" else ""}
             )
-            -- Filtro Final: Retorna apenas o que for DEVICE na árvore inteira
             SELECT entity_id 
             FROM entity_tree 
             WHERE entity_type = 'DEVICE'
@@ -161,5 +187,4 @@ class ThingsBoardDashboardService(
             Id(entityType = "DEVICE", id = UUID.fromString(rs.getString("entity_id")))
         }
     }
-
 }

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/ThingsBoardDashboardService.kt
@@ -3,7 +3,6 @@ package com.ifpe.edu.br.airpowerserver.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.ifpe.edu.br.airpowerserver.dto.Id
-import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardConfig
 import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardConfiguration
 import com.ifpe.edu.br.airpowerserver.dto.dashboards.DashboardInfo
 import org.slf4j.LoggerFactory
@@ -62,7 +61,7 @@ class ThingsBoardDashboardService(
     /**
      * Busca os IDs de dispositivos únicos de um dashboard específico.
      */
-    fun getDeviceIdsFromDashboard(customerId: UUID, dashboardId: String): List<Id> {
+    fun getDeviceIdsFromDashboard(dashboardId: String): List<Id> {
         val sqlConfig = "SELECT configuration::text FROM dashboard WHERE id = :dashboardId"
         val params = MapSqlParameterSource().addValue("dashboardId", UUID.fromString(dashboardId))
 
@@ -77,11 +76,8 @@ class ThingsBoardDashboardService(
                 val filter = alias.filter ?: return@forEach
 
                 when (filter.type) {
-                    // ---------------------------------------------------------
                     // OPÇÃO 1: Lista Manual (Entity List)
-                    // Útil para grupos pequenos e fixos (ex: A e B)
                     // Configurado na GUI como Filter Type: "Entity List"
-                    // ---------------------------------------------------------
                     "entityList" -> {
                         filter.entityList?.forEach { idStr ->
                             try {
@@ -89,19 +85,14 @@ class ThingsBoardDashboardService(
                             } catch (e: Exception) { logger.warn("UUID inválido na lista: $idStr") }
                         }
                     }
-
-                    // ---------------------------------------------------------
-                    // OPÇÃO 2: Relations Query (A solução robusta)
+                    // OPÇÃO 2: Relations Query
                     // Busca devices conectados a um Asset específico.
-                    // ---------------------------------------------------------
                     "relationsQuery" -> {
                         val rootId = filter.rootEntity?.id
                         val direction = filter.direction // FROM ou TO
                         // Se o usuário não definir relationType na GUI, o TB às vezes omite ou usa "Contains"
                         val relationType = filter.relationType
-
                         if (rootId != null && direction != null) {
-                            // Busca dinâmica na tabela de relações
                             val relations = findRelatedDevices(
                                 UUID.fromString(rootId),
                                 direction,
@@ -110,13 +101,9 @@ class ThingsBoardDashboardService(
                             deviceIds.addAll(relations)
                         }
                     }
-
-                    // ... outros casos (singleEntity, etc) ...
                 }
             }
-
             return deviceIds.toList()
-
         } catch (e: Exception) {
             logger.error("Erro ao resolver dashboard {}: {}", dashboardId, e.message)
             return emptyList()
@@ -124,38 +111,54 @@ class ThingsBoardDashboardService(
     }
 
     /**
-     * Busca na tabela 'relation' do ThingsBoard.
-     * Estrutura da tabela: from_id, from_type, to_id, to_type, relation_type_group, relation_type
+     * Busca RECURSIVAMENTE na tabela 'relation' do ThingsBoard.
+     * Encontra todos os dispositivos descendentes, não importa a profundidade (Asset -> Asset -> Device).
      */
     private fun findRelatedDevices(rootEntityId: UUID, direction: String, relationType: String?): List<Id> {
-        // Se direction é FROM, o Asset é o 'from_id' e buscamos os 'to_id' (os devices)
-        // Se direction é TO, o Asset é o 'to_id' (menos comum para agrupamento)
-
         val isFrom = direction.equals("FROM", ignoreCase = true)
 
-        val selectColumn = if (isFrom) "to_id" else "from_id"
-        val whereColumn = if (isFrom) "from_id" else "to_id"
-        // Garantimos que só retornamos dispositivos
-        val targetTypeColumn = if (isFrom) "to_type" else "from_type"
+        // Se a direção é FROM (Root -> Filhos), a recursão segue from_id -> to_id.
+        val parentColumn = if (isFrom) "from_id" else "to_id"
+        val childColumn = if (isFrom) "to_id" else "from_id"
+        val childTypeColumn = if (isFrom) "to_type" else "from_type"
 
-        var sql = """
-            SELECT $selectColumn as device_id 
-            FROM relation 
-            WHERE $whereColumn = :rootId 
-              AND $targetTypeColumn = 'DEVICE'
-              AND relation_type_group = 'COMMON'
+        // SQL Recursivo para PostgreSQL
+        val sql = """
+            WITH RECURSIVE entity_tree AS (
+                -- Caso Base: Encontra os filhos diretos da Entidade Raiz (ex: Campus -> Bloco A)
+                SELECT 
+                    $childColumn as entity_id, 
+                    $childTypeColumn as entity_type
+                FROM relation 
+                WHERE $parentColumn = :rootId
+                  AND relation_type_group = 'COMMON'
+                  ${if (!relationType.isNullOrBlank()) "AND relation_type = :relType" else ""}
+                
+                UNION ALL
+                
+                -- Passo Recursivo: Encontra os filhos dos filhos (ex: Bloco A -> Device)
+                SELECT 
+                    r.$childColumn, 
+                    r.$childTypeColumn
+                FROM relation r
+                INNER JOIN entity_tree et ON r.$parentColumn = et.entity_id
+                WHERE r.relation_type_group = 'COMMON'
+                  ${if (!relationType.isNullOrBlank()) "AND r.relation_type = :relType" else ""}
+            )
+            -- Filtro Final: Retorna apenas o que for DEVICE na árvore inteira
+            SELECT entity_id 
+            FROM entity_tree 
+            WHERE entity_type = 'DEVICE'
         """
 
         val params = MapSqlParameterSource().addValue("rootId", rootEntityId)
 
-        // Adiciona filtro por tipo de relação se especificado (ex: 'Contains')
         if (!relationType.isNullOrBlank()) {
-            sql += " AND relation_type = :relType"
             params.addValue("relType", relationType)
         }
 
         return namedJdbcTemplate.query(sql, params) { rs, _ ->
-            Id(entityType = "DEVICE", id = UUID.fromString(rs.getString("device_id")))
+            Id(entityType = "DEVICE", id = UUID.fromString(rs.getString("entity_id")))
         }
     }
 


### PR DESCRIPTION
Highlights
Nova Funcionalidade de Dashboards: Foi adicionada uma nova lógica para recuperar dashboards e os dispositivos associados a eles, permitindo a extração de IDs de dispositivos diretamente da configuração do dashboard, incluindo filtros de alias de entidade baseados em listas ou consultas de relações.
Novo Controller REST para Dashboards: Um novo DashboardController foi introduzido para expor endpoints REST para buscar dashboards de um usuário específico e IDs de dispositivos de um determinado dashboard.
Serviço de Dashboards com Acesso Direto ao DB: Um novo ThingsBoardDashboardService foi criado para interagir diretamente com o banco de dados do ThingsBoard, otimizando a recuperação de informações de dashboards e dispositivos através de consultas SQL, incluindo consultas recursivas para relações de entidades.
Melhorias no Serviço de Alarmes: O ThingsBoardAlarmService foi atualizado para buscar alarmes ativos não reconhecidos por padrão e inclui uma nova função dedicada para recuperar alarmes não reconhecidos, melhorando a filtragem de alarmes.
Novos DTOs para Configuração de Dashboards: Várias classes DTO (Data Transfer Object) foram adicionadas para modelar a estrutura complexa das configurações de dashboards do ThingsBoard, como DashboardConfig, DashboardConfiguration, AliasFilter, EntityAlias, Widget, WidgetConfig, Datasource e SingleEntity.
Atualização de Dependência: A dependência do PostgreSQL em build.gradle.kts foi alterada de runtimeOnly para implementation, garantindo que o driver esteja disponível em tempo de compilação para todas as dependências transitivas.