### PR TITLE
feat: Implement dashboard and device retrieval and enhance alarm filt…

### DIFF
--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/NotificationController.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/controller/NotificationController.kt
@@ -11,8 +11,18 @@ import com.ifpe.edu.br.airpowerserver.service.ThingsBoardUserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
-import java.util.*
 
+/**
+ * REST Controller for managing user notifications.
+ *
+ * This controller provides endpoints for authenticated users to retrieve their notifications
+ * and to mark specific notifications as read. It interacts with [NotificationService]
+ * and [ThingsBoardUserService] to fetch and update notification data.
+ *
+ * @property notificationService The service responsible for notification-related business logic.
+ * @property airPowerUserRepository Repository for accessing AirPower user data.
+ * @property thingsBoardService Service for interacting with ThingsBoard user-related functionalities.
+ */
 @RestController
 @RequestMapping("/api/v1/notifications")
 class NotificationController(
@@ -21,6 +31,15 @@ class NotificationController(
     private val thingsBoardService: ThingsBoardUserService,
 ) {
 
+    /**
+     * Retrieves all unread notifications for the currently authenticated user.
+     *
+     * The user's identity is extracted from the security context. If the user cannot be
+     * identified, a [DownstreamServiceException] is thrown.
+     *
+     * @return A [ResponseEntity] containing a list of [AirPowerNotificationItem] for the user.
+     * @throws DownstreamServiceException if the authenticated user's information cannot be found.
+     */
     @GetMapping("/me")
     fun getMyNotifications(): ResponseEntity<List<AirPowerNotificationItem>> {
         val authentication = SecurityContextHolder.getContext().authentication
@@ -33,11 +52,23 @@ class NotificationController(
         } else {
             val storedAirPowerUser = airPowerUserRepository.findByEmail(username)
             val thingsBoardUserFromApi = thingsBoardService.getCurrentUser(storedAirPowerUser.id!!)
-            val notifications = notificationService.getNotificationsForUser(thingsBoardUserFromApi.id.id)
+            val notifications = notificationService.getUnreadNotificationsForUser(thingsBoardUserFromApi.id.id)
             ResponseEntity.ok(notifications)
         }
     }
 
+    /**
+     * Marks a specific notification as read for the currently authenticated user.
+     *
+     * The notification to be marked is identified by its [Id] provided in the request body.
+     * The user's identity is extracted from the security context. If the user cannot be
+     * identified, a [DownstreamServiceException] is thrown.
+     *
+     * @param id The [Id] object containing the UUID of the notification to mark as read.
+     * @return A [ResponseEntity] containing `true` if the notification was successfully
+     *         marked as read, `false` otherwise.
+     * @throws DownstreamServiceException if the authenticated user's information cannot be found.
+     */
     @PostMapping("/read")
     fun refresh(
         @RequestBody id: Id
@@ -46,7 +77,7 @@ class NotificationController(
         val username = authentication?.name
         return if (username == null) {
             throw DownstreamServiceException(
-ErrorCode.INVALID_AIRPOWER_TOKEN,
+                ErrorCode.INVALID_AIRPOWER_TOKEN,
                 "user could not be found"
             )
         } else {

--- a/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/NotificationService.kt
+++ b/src/main/kotlin/com/ifpe/edu/br/airpowerserver/service/NotificationService.kt
@@ -15,6 +15,15 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 import java.util.*
 
+/**
+ * Service responsible for managing user notifications by interacting with the ThingsBoard API.
+ *
+ * This class handles fetching notifications for a specific user and marking them as read.
+ * It communicates with the ThingsBoard external service to perform these operations.
+ *
+ * @property restTemplate The Spring RestTemplate for making HTTP requests.
+ * @property tbServiceUtil A utility service for handling common ThingsBoard API interactions, such as authentication.
+ */
 @Service
 class NotificationService(
     private val restTemplate: RestTemplate,
@@ -26,14 +35,20 @@ class NotificationService(
     private val logger = LoggerFactory.getLogger(NotificationService::class.java)
 
     /**
-     * Busca as notificações mais recentes para um usuário diretamente da API do ThingsBoard.
+     * Retrieves notifications for a user from the ThingsBoard API.
      *
-     * @param userId O UUID do usuário logado no sistema AirPower.
-     * @return Uma lista de [AirPowerNotificationItem] ordenada da mais recente para a mais antiga.
+     * This method fetches the 50 most recent unread notifications for the specified user.
+     * The results are sorted by creation time in descending order (newest first).
+     * Each notification is then transformed into a standardized [AirPowerNotificationItem].
+     *
+     * @param userId The UUID of the user whose notifications are to be fetched.
+     * @return A list of [AirPowerNotificationItem] representing the user's unread notifications.
+     *         Returns an empty list if an error occurs or no notifications are found.
      */
-    fun getNotificationsForUser(userId: UUID): List<AirPowerNotificationItem> {
+    fun getUnreadNotificationsForUser(userId: UUID): List<AirPowerNotificationItem> {
         logger.info("Fetching notifications from ThingsBoard for user: $userId")
-        val url = "$thingsBoardApiUrl/api/notifications?page=0&pageSize=50&sortProperty=createdTime&sortOrder=DESC"
+        val url =
+            "$thingsBoardApiUrl/api/notifications?page=0&pageSize=50&sortProperty=createdTime&sortOrder=DESC&unreadOnly=true"
         val requestEntity = HttpEntity<String>(tbServiceUtil.getAuthHeaders(userId))
         try {
             val response =
@@ -49,10 +64,13 @@ class NotificationService(
     }
 
     /**
-     * Transforma um objeto de notificação do ThingsBoard em um item de notificação padronizado.
+     * Transforms a [ThingsBoardNotification] object into a standardized [AirPowerNotificationItem].
      *
-     * @param tbNotification O [ThingsBoardNotification] a ser transformado.
-     * @return Um objeto [AirPowerNotificationItem].
+     * This private helper method maps the fields from the source object, including the nested
+     * `info` object, to the flattened structure of [AirPowerNotificationItem].
+     *
+     * @param tbNotification The source [ThingsBoardNotification] object from the ThingsBoard API.
+     * @return An [AirPowerNotificationItem] containing the standardized notification data.
      */
     private fun transformTbNotificationToNotificationItem(
         tbNotification: ThingsBoardNotification
@@ -74,12 +92,22 @@ class NotificationService(
         )
     }
 
+    /**
+     * Marks a specific notification as read for a user.
+     *
+     * This method sends a PUT request to the ThingsBoard API to update the status of a
+     * notification to 'READ'.
+     *
+     * @param notificationId The [Id] of the notification to be marked as read.
+     * @param thingsBoardUserFromApi The [ThingsBoardUser] object, used to get authentication credentials.
+     * @return `true` if the notification was successfully marked as read (HTTP 200 OK), `false` otherwise.
+     */
     fun markAsRead(
         notificationId: Id,
         thingsBoardUserFromApi: ThingsBoardUser
     ): Boolean {
         logger.info("markAsRead: id: $notificationId user: $thingsBoardUserFromApi")
-val url = "$thingsBoardApiUrl/api/notification/${notificationId.id}/read"
+        val url = "$thingsBoardApiUrl/api/notification/${notificationId.id}/read"
         val requestEntity = HttpEntity<String>(tbServiceUtil.getAuthHeaders(thingsBoardUserFromApi.id.id))
         try {
             val response =


### PR DESCRIPTION
This commit introduces significant new features for handling dashboards and improves alarm management.

- **Dashboard and Device Retrieval:**
  - Implemented a new `ThingsBoardDashboardService` to fetch dashboard and device information directly from the ThingsBoard database, optimizing performance.
  - Added a `DashboardController` with REST endpoints to expose dashboard data for users and retrieve device IDs from specific dashboards.
  - Created a suite of DTOs (`DashboardConfig`, `EntityAlias`, `Widget`, etc.) to accurately model ThingsBoard's dashboard configurations.
  - The logic supports extracting device IDs from entity aliases, including static lists and dynamic relation queries.

- **Alarm Service Enhancements:**
  - Updated `ThingsBoardAlarmService` to filter for active, unacknowledged alarms by default.
  - Added a dedicated function to retrieve only unacknowledged alarms, improving filtering capabilities.

- **Dependency Update:**
  - Changed the PostgreSQL dependency scope in `build.gradle.kts` from `runtimeOnly` to `implementation` to ensure the driver is available at compile time for all transitive dependencies.